### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+language: scala
+scala:
+  - 2.11.11
+jdk:
+  - oraclejdk8
+  - openjdk8
+test:
+  - sbt ++$TRAVIS_SCALA_VERSION test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dynamic configuration tools
 
+[![Build Status](https://travis-ci.org/ASIDataScience/dynamic-configuration.svg)](https://travis-ci.org/ASIDataScience/dynamic-configuration)
+
 This repository provides tools for setting up configuration that refreshes at
 particular intervals. It assumes that the current configuration lives in a file
 on Amazon S3. It tries to refresh the configuration at regular intervals.


### PR DESCRIPTION
This PR adds a Travis CI configuration to run the unit tests on each push, with Scala 2.11.11 on Oracle JDK 8 and OpenJDK 8 initially. This can be expanded once cross compilation with Scala 2.12.x is configured.