### PR TITLE
Replace uses of Try#get

### DIFF
--- a/src/main/scala/com/asidatascience/configuration/DynamicConfigurationFromS3.scala
+++ b/src/main/scala/com/asidatascience/configuration/DynamicConfigurationFromS3.scala
@@ -19,9 +19,9 @@ object DynamicConfigurationFromS3 {
 
     DynamicConfiguration(refreshOptions) {
       Future {
-        val contents: String = s3Client.getObjectAsString(bucket, key)
-        val configurationTry = parser(contents)
-        configurationTry.get
+        s3Client.getObjectAsString(bucket, key)
+      }.flatMap { contents =>
+        Future.fromTry { parser(contents) }
       }
     }
   }


### PR DESCRIPTION
The [`Try#get`](http://www.scala-lang.org/api/2.11.x/index.html#scala.util.Try@get:T) method will throw if the value is a `Failure`, and the exception could be exposed during refactoring. This commit removes all uses of `Try#get` in favour of using [`Future#fromTry`](http://www.scala-lang.org/api/2.11.x/index.html#scala.concurrent.Future$@fromTry[T](result:scala.util.Try[T]):scala.concurrent.Future[T]).