### PR TITLE
Enable static analysis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,26 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-test" % "2.5.14" % "test"
 )
 
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "utf-8",
+  "-feature",
+  "-unchecked",
+  "-Xcheckinit",
+  "-Xlint:_",
+  "-Yno-adapted-args",
+  "-Ypartial-unification",
+  "-Ywarn-dead-code",
+  "-Ywarn-inaccessible",
+  "-Ywarn-infer-any",
+  "-Ywarn-nullary-override",
+  "-Ywarn-nullary-unit",
+  "-Ywarn-numeric-widen",
+  "-Ywarn-unused",
+  "-Ywarn-unused-import",
+  "-Ywarn-value-discard"
+)
+
 addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")
 
 publishMavenStyle := false

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-test" % "2.5.14" % "test"
 )
 
-scalacOptions ++= Seq("-feature", "-deprecation", "-Ywarn-unused-import")
+addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")
 
 publishMavenStyle := false
 


### PR DESCRIPTION
This PR adds additional compiler flags and a [compiler plugin](https://github.com/HairyFotr/linter) for static analysis. These additional checks raise multiple warnings, but as fixes for some of them exist in other PRs I think it's preferable to merge those others PRs before rebasing this branch on master.