### PR TITLE
Introduce BaseSpec class for test suites

### DIFF
--- a/src/test/scala/com/asidatascience/configuration/BaseSpec.scala
+++ b/src/test/scala/com/asidatascience/configuration/BaseSpec.scala
@@ -1,0 +1,42 @@
+package com.asidatascience.configuration
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.duration._
+import scala.util.{Success, Try}
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+abstract class BaseSpec
+extends TestKit(ActorSystem("base-spec"))
+with FlatSpecLike
+with Matchers
+with BeforeAndAfterAll
+with ScalaFutures {
+
+  override implicit val patienceConfig = PatienceConfig(
+    timeout = 5.seconds, interval = 50.millis)
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  case class Configuration(timestamp: Long)
+
+  protected val dummyConfiguration = Configuration(1L)
+  protected val dummyContents = "dummy-contents"
+
+  class TestConfigurationParser(expectedContents: String) {
+    val nHits = new AtomicInteger(0)
+
+    def parse(contents: String): Try[Configuration] = {
+      contents shouldEqual expectedContents
+      nHits.incrementAndGet()
+      val config = dummyConfiguration
+      Success(config)
+    }
+  }
+
+}

--- a/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromS3Spec.scala
+++ b/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromS3Spec.scala
@@ -1,12 +1,9 @@
 package com.asidatascience.configuration
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.util.{Success, Try}
+import scala.util.Try
 
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
 import com.amazonaws.services.s3.AmazonS3
 import org.mockito.Mockito.when
 import org.scalatest._
@@ -14,44 +11,17 @@ import org.scalatest.concurrent._
 import org.scalatest.mockito.MockitoSugar
 
 class DynamicConfigurationFromS3Spec
-extends TestKit(ActorSystem("dynamic-configuration-from-s3-spec"))
-with FlatSpecLike
-with Matchers
-with BeforeAndAfterAll
+extends BaseSpec
 with Eventually
 with Inside
-with MockitoSugar
-with ScalaFutures {
+with MockitoSugar {
 
-  override implicit val patienceConfig = PatienceConfig(
-    timeout = 5.seconds, interval = 50.millis)
+  private val dummyBucket = "test-bucket"
+  private val dummyKey = "test-key"
 
-  override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-  }
-
-  case class Configuration(timestamp: Long)
-
-  val dummyConfiguration = Configuration(1L)
-
-  val dummyS3Contents = "dummy-contents"
-  val dummyBucket = "test-bucket"
-  val dummyKey = "test-key"
-
-  val mockS3Client = mock[AmazonS3]
+  private val mockS3Client = mock[AmazonS3]
   when(mockS3Client.getObjectAsString(dummyBucket, dummyKey))
-    .thenReturn(dummyS3Contents)
-
-  trait TestConfigurationParser {
-    val nHits = new AtomicInteger(0)
-
-    def parse(contents: String): Try[Configuration] = {
-      contents shouldEqual dummyS3Contents
-      nHits.incrementAndGet()
-      val config = dummyConfiguration
-      Success(config)
-    }
-  }
+    .thenReturn(dummyContents)
 
   def newDynamicConfiguration(
     parse: String => Try[Configuration]
@@ -64,13 +34,13 @@ with ScalaFutures {
     )(parse)
 
   "DynamicConfigurationFromS3" should "return None initially" in {
-    val parser = new TestConfigurationParser {}
+    val parser = new TestConfigurationParser(dummyContents)
     val configuration = newDynamicConfiguration(parser.parse)
     configuration.currentConfiguration shouldEqual None
   }
 
   it should "register an initial configuration" in {
-    val parser = new TestConfigurationParser {}
+    val parser = new TestConfigurationParser(dummyContents)
     val configuration =
       newDynamicConfiguration(parser.parse)
 

--- a/src/test/scala/com/asidatascience/configuration/DynamicConfigurationSpec.scala
+++ b/src/test/scala/com/asidatascience/configuration/DynamicConfigurationSpec.scala
@@ -5,30 +5,15 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
 import org.scalatest._
 import org.scalatest.concurrent._
 
 class DynamicConfigurationSpec
-extends TestKit(ActorSystem("dynamic-configuration-spec"))
-with FlatSpecLike
-with Matchers
-with BeforeAndAfterAll
+extends BaseSpec
 with Eventually
-with Inside
-with ScalaFutures {
+with Inside {
 
   case object IntentionalException extends Exception("intentional exception")
-
-  override implicit val patienceConfig = PatienceConfig(
-    timeout = 5.seconds, interval = 50.millis)
-
-  override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-  }
-
-  case class Configuration(timestamp: Long)
 
   private def newConfiguration = Configuration(System.nanoTime)
 


### PR DESCRIPTION
This PR extracts a `BaseSpec` class containing common test fixtures, to reduce test code duplication.