### PR TITLE
Use Play logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,6 @@ git.useGitDescribe := true
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.4.17",
   "com.typesafe.play" %% "play-ws" % "2.5.14",
-  "ch.qos.logback" % "logback-classic" % "1.2.1",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.98",
   "com.typesafe.akka" %% "akka-testkit" % "2.4.17" % "test",
   "org.mockito" % "mockito-core" % "2.7.14" % "test",

--- a/src/main/scala/com/asidatascience/configuration/DynamicConfiguration.scala
+++ b/src/main/scala/com/asidatascience/configuration/DynamicConfiguration.scala
@@ -7,7 +7,7 @@ import scala.concurrent.{Future, ExecutionContext}
 
 import java.util.concurrent.atomic.AtomicReference
 
-import com.typesafe.scalalogging.Logger
+import play.api.Logger
 
 trait DynamicConfiguration[T] {
   def currentConfiguration: Option[T]


### PR DESCRIPTION
This PR changes the logging library used from Lightbend's [scala-logging](https://github.com/typesafehub/scala-logging) to that of the [Play framework](https://www.playframework.com/documentation/2.5.x/ScalaLogging). This is to fix incompatibilities between the two experienced in ASI's internal Play applications.