### PR TITLE
Remove Travis configuration value that is default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: scala
 scala:
   - 2.11.11


### PR DESCRIPTION
Trusty based container builds have been the Travis CI default since August 2017 ([docs](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System)).