### PR TITLE
Log whenever dynamic configuration is parsed

### DIFF
--- a/src/main/scala/com/asidatascience/configuration/DynamicConfiguration.scala
+++ b/src/main/scala/com/asidatascience/configuration/DynamicConfiguration.scala
@@ -56,11 +56,13 @@ trait DynamicConfigurationImpl[T] extends DynamicConfiguration[T] {
       updateConfiguration.onComplete {
         case Success(newConfiguration)
             if oldConfigurationMaybe.contains(newConfiguration) =>
+          log.debug("Dynamic configuration unchanged from current version.")
         case Success(newConfiguration) =>
           currentConfigurationReference.compareAndSet(oldConfigurationMaybe,
                                                       Some(newConfiguration))
+          log.info("Dynamic configuration updated with new version.")
         case Failure(t) =>
-          log.warn("Failed to update current configuration. " +
+          log.warn("Failed to update dynamic configuration. " +
                      "Falling back to previous version.",
                    t)
       }

--- a/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromHttpSpec.scala
+++ b/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromHttpSpec.scala
@@ -16,7 +16,7 @@ class DynamicConfigurationFromHttpSpec
     with Inside {
 
   override implicit val patienceConfig =
-    PatienceConfig(timeout = 1.seconds, interval = 50.millis)
+    PatienceConfig(timeout = 2.seconds, interval = 50.millis)
 
   private def withDynamicConfiguration(parser: TestConfigurationParser)(
       block: DynamicConfiguration[Configuration] => Any): Unit =

--- a/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromS3Spec.scala
+++ b/src/test/scala/com/asidatascience/configuration/DynamicConfigurationFromS3Spec.scala
@@ -30,7 +30,7 @@ class DynamicConfigurationFromS3Spec
       mockS3Client,
       dummyBucket,
       dummyKey,
-      RefreshOptions(100.millis, 300.millis)
+      RefreshOptions(100.millis, 1000.millis)
     )(parse)
 
   "DynamicConfigurationFromS3" should "return None initially" in {


### PR DESCRIPTION
Previously, logging only occurred when there was a failure parsing the dynamic configuration. To aid debugging, we now additionally log when the dynamic configuration is successfully parsed.

Closes #25.