### PR TITLE
Remove S3 resolver configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,12 +40,6 @@ addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")
 
 publishMavenStyle := true
 
-s3region := com.amazonaws.services.s3.model.Region.EU_Ireland
-
-s3credentials := new com.amazonaws.auth.DefaultAWSCredentialsProviderChain()
-
-s3acl := com.amazonaws.services.s3.model.CannedAccessControlList.Private
-
 publishTo := Some(
   if (isSnapshot.value)
     Opts.resolver.sonatypeSnapshots

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.16.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")


### PR DESCRIPTION
This is no longer required now dynamic-configuration is published to Sonatype.