### PR TITLE
Scala 2.13

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,2 @@
-version=2.7.5
 project.excludeFilters = [build.sbt, .scalafmt.conf]
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
+version=2.7.5
 project.excludeFilters = [build.sbt, .scalafmt.conf]
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.12
+  - 2.13.4
 jdk:
   - openjdk8
 test:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "ai.faculty"
 
 name := "dynamic-configuration"
 
-version := "0.4.0-SNAPSHOT"
+version := "0.4.0"
 
 scalaVersion := "2.13.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,14 @@ scalaVersion := "2.13.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.6.10",
+  // Not used but needs to be pinned for compatibility. See
+  //  https://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed
+  "com.typesafe.akka" %% "akka-stream" % "2.6.10",
   "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.1.2",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.408",
   "com.typesafe.akka" %% "akka-testkit" % "2.6.10" % "test",
-  "org.mockito" % "mockito-core" % "2.22.0" % "test",
-  "org.scalatest" %% "scalatest" % "3.1.0" % "test"
+  "org.scalatestplus" %% "mockito-3-4" % "3.2.2.0" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.9" % "test"
 )
 
 scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "ai.faculty"
 
 name := "dynamic-configuration"
 
-version := "0.3.3"
+version := "0.4.0-SNAPSHOT"
 
 scalaVersion := "2.13.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,15 @@ name := "dynamic-configuration"
 
 version := "0.3.3"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.4"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.5.16",
-  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.2",
+  "com.typesafe.akka" %% "akka-actor" % "2.6.10",
+  "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.1.2",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.408",
-  "com.typesafe.akka" %% "akka-testkit" % "2.5.14" % "test",
+  "com.typesafe.akka" %% "akka-testkit" % "2.6.10" % "test",
   "org.mockito" % "mockito-core" % "2.22.0" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 )
 
 scalacOptions ++= Seq(
@@ -23,20 +23,11 @@ scalacOptions ++= Seq(
   "-unchecked",
   "-Xcheckinit",
   "-Xlint:_",
-  "-Yno-adapted-args",
-  "-Ypartial-unification",
   "-Ywarn-dead-code",
-  "-Ywarn-inaccessible",
-  "-Ywarn-infer-any",
-  "-Ywarn-nullary-override",
-  "-Ywarn-nullary-unit",
   "-Ywarn-numeric-widen",
   "-Ywarn-unused",
-  "-Ywarn-unused-import",
   "-Ywarn-value-discard"
 )
-
-addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")
 
 publishMavenStyle := true
 

--- a/examples/simple/Simple.scala
+++ b/examples/simple/Simple.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import ai.faculty.configuration.{
-  DynamicConfigurationFromS3,
+  DynamicConfiguration,
   RefreshOptions
 }
 import org.json4s._
@@ -58,9 +58,9 @@ class WidgetFrozzler(
         println(s"Configuration not ready")
     }
 
-  def shutdown: Future[_] = {
-    configurationService.stop
-    actorSystem.terminate
+  def shutdown(): Future[_] = {
+    configurationService.stop()
+    actorSystem.terminate()
   }
 }
 
@@ -76,5 +76,5 @@ object Simple extends App {
     Thread.sleep(1000)
   }
 
-  Await.ready(frozzler.shutdown, 5.seconds)
+  Await.ready(frozzler.shutdown(), 5.seconds)
 }

--- a/examples/simple/build.sbt
+++ b/examples/simple/build.sbt
@@ -1,6 +1,6 @@
 name := "dynamic-configuration-simple-example"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.4.14",

--- a/examples/simple/build.sbt
+++ b/examples/simple/build.sbt
@@ -3,10 +3,10 @@ name := "dynamic-configuration-simple-example"
 scalaVersion := "2.13.4"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.4.14",
+  "com.typesafe.akka" %% "akka-actor" % "2.6.10",
   "com.amazonaws" % "aws-java-sdk" % "1.11.66",
-  "ai.faculty" %% "dynamic-configuration" % "0.3.0",
-  "org.json4s" %% "json4s-native" % "3.5.0"
+  "ai.faculty" %% "dynamic-configuration" % "0.4.0-SNAPSHOT",
+  "org.json4s" %% "json4s-native" % "3.6.10"
 )
 
-scalacOptions ++= Seq("-feature", "-deprecation", "-Ywarn-unused-import")
+scalacOptions ++= Seq("-feature", "-deprecation")

--- a/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
+++ b/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
@@ -9,6 +9,7 @@ import scala.util.{Failure, Success, Try}
 import akka.actor.{ActorSystem, Cancellable}
 import akka.event.Logging
 import com.amazonaws.services.s3.AmazonS3
+import akka.event.LogSource
 
 trait DynamicConfiguration[T] {
   def currentConfiguration: Option[T]
@@ -72,7 +73,13 @@ trait DynamicConfigurationImpl[T] extends DynamicConfiguration[T] {
   implicit def actorSystem: ActorSystem
   implicit def executionContext: ExecutionContext
 
-  private val log = Logging(actorSystem, this.getClass)
+  private implicit val logSource: LogSource[DynamicConfigurationImpl[_]] = 
+    new LogSource[DynamicConfigurationImpl[_]] {
+      override def genString(t: DynamicConfigurationImpl[_]): String = 
+        DynamicConfigurationImpl.this.getClass.getName
+    }
+
+  private val log = Logging(actorSystem, this)
 
   override def currentConfiguration: Option[T] =
     currentConfigurationReference.get()

--- a/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
+++ b/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
@@ -91,7 +91,7 @@ trait DynamicConfigurationImpl[T] extends DynamicConfiguration[T] {
 
   def start(): Unit = {
     val RefreshOptions(delay, interval) = options
-    val task = actorSystem.scheduler.schedule(delay, interval) {
+    val task = actorSystem.scheduler.scheduleWithFixedDelay(delay, interval) { () =>
       val oldConfigurationMaybe = currentConfigurationReference.get
       updateConfiguration.onComplete {
         case Success(newConfiguration)
@@ -110,5 +110,5 @@ trait DynamicConfigurationImpl[T] extends DynamicConfiguration[T] {
     timer = Some(task)
   }
 
-  override def stop(): Unit = timer.foreach { _.cancel }
+  override def stop(): Unit = timer.foreach { _.cancel() }
 }

--- a/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
+++ b/src/main/scala/ai/faculty/configuration/DynamicConfiguration.scala
@@ -76,7 +76,7 @@ trait DynamicConfigurationImpl[T] extends DynamicConfiguration[T] {
   private implicit val logSource: LogSource[DynamicConfigurationImpl[_]] = 
     new LogSource[DynamicConfigurationImpl[_]] {
       override def genString(t: DynamicConfigurationImpl[_]): String = 
-        DynamicConfigurationImpl.this.getClass.getName
+        classOf[DynamicConfigurationImpl[_]].getName()
     }
 
   private val log = Logging(actorSystem, this)

--- a/src/test/scala/ai/faculty/configuration/DynamicConfigurationFromS3Spec.scala
+++ b/src/test/scala/ai/faculty/configuration/DynamicConfigurationFromS3Spec.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.s3.AmazonS3
 import org.mockito.Mockito.when
 import org.scalatest._
 import org.scalatest.concurrent._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DynamicConfigurationFromS3Spec
     extends BaseSpec


### PR DESCRIPTION
This PR upgrades the codebase to Scala 2.13, which requires:

- fixing some dependency version/conflicts
- changing some imports because of changes in our dependencies
- removing some compiler flags which are no longer supported
- removing the obsolete linter plugins which doesn't support 2.13 (and is no longer maintained)
- dealing with some breaking changes in akka API

This is necessary for project that use this library to be able to upgrade to Scala 2.13. And it's a breaking change, so an upgrade to 2.13 will be required for newer version.

In principle, we could support multiple Scala versions, by cross-compiling, but there's no demand for it, so it's not worth the effort.